### PR TITLE
Add troubleshooting step for ImagePullBackOff due to invalid or expired registry credentials

### DIFF
--- a/Agartala/v0.2.0/CORE/documentation/IOS-MCN CORE Installation Guide.md
+++ b/Agartala/v0.2.0/CORE/documentation/IOS-MCN CORE Installation Guide.md
@@ -202,7 +202,7 @@ Start installation with the command
 
 ```
 cd IOSMCN-CoreDpm
-make aether-k8s-install
+make iosmcn-k8s-install
 ```
 
 This may take several minutes to complete the installation. On its completion, verify the installation status by the command
@@ -222,7 +222,7 @@ Figure 2: Output of Kubernetes installation
 Initiate the installation by the command
 
 ```
-make aether-5gc-install
+make iosmcn-5gc-install
 ```
 
 The successful outcome shall be verified using the following command

--- a/Agartala/v0.2.0/CORE/documentation/IOS-MCN CORE Troubleshooting Guide.md
+++ b/Agartala/v0.2.0/CORE/documentation/IOS-MCN CORE Troubleshooting Guide.md
@@ -15,7 +15,7 @@ This document envisages a developer or user to solve the error or issues may fac
 ###	Error/Issue 1
 -	Issue Title: Data sent error
 -	Description: Data could not be sent to remote host
--	Common Solutions: Update ansible.cfg in aether-onramp with following replacement 
+-	Common Solutions: Update ansible.cfg in IOSMCN-CoreDpm with following replacement 
  *#pipelining = True*
 ###	Error/Issue 2:
 -	Issue Title: ansible include removed 
@@ -88,7 +88,6 @@ kubectl describe pod <podname> -n <namespace>
 ```
 kubectl -n iosmcn get pods	
 kubectl get pods --all-namespaces -o wide (Displays IP address details also)
-kubectl -n aether-roc get pods	
 kubectl logs pod-name -n iosmcn (To get logs from a pod)
 ```
 ###	Error/Issue 12


### PR DESCRIPTION
This PR updates the Troubleshooting Guide with an additional entry (Error/Issue 32) describing the ImagePullBackOff problem caused by invalid or expired registry credentials in containerd. It provides a clear resolution by removing the old Docker configuration file and restarting the RKE2 server to reload authentication.