### PR TITLE
Update IOS-MCN CORE Installation Guide.md

### DIFF
--- a/Agartala/v0.2.0/CORE/documentation/IOS-MCN CORE Installation Guide.md
+++ b/Agartala/v0.2.0/CORE/documentation/IOS-MCN CORE Installation Guide.md
@@ -138,7 +138,7 @@ sudo netplan apply
 Download file [iosmcn.agartala.v0.2.0.core.images.tar.gz](../release-images/iosmcn.agartala.v0.2.0.core.images.tar.gz) to the directory.
 
 ```
-wget https://github.com/ios-mcn/ios-mcn-releases/raw/refs/heads/main/Agartala/v0.2.0/CORE/release-images/iosmcn.agartala.v0.2.0.core.images.tar.gz
+wget https://raw.githubusercontent.com/ios-mcn/ios-mcn-releases/main/Agartala/v0.2.0/CORE/release-images/iosmcn.agartala.v0.2.0.core.images.tar.gz
 tar -xvzf iosmcn.agartala.v0.2.0.core.images.tar.gz
 cd iosmcn.agartala.v0.2.0.core.images/IOSMCN-CoreDpm
 ```


### PR DESCRIPTION
This PR fixes the incorrect GitHub web link that caused .tar.gz downloads to fail. This ensures users can directly download the release images using wget or curl.