### PR TITLE
Update download link for IOS-MCN CORE images

### DIFF
--- a/Agartala/v0.2.0/CORE/documentation/IOS-MCN CORE Installation Guide.md
+++ b/Agartala/v0.2.0/CORE/documentation/IOS-MCN CORE Installation Guide.md
@@ -140,7 +140,7 @@ Download file [iosmcn.agartala.v0.2.0.core.images.tar.gz](../release-images/iosm
 ```
 wget https://github.com/ios-mcn/ios-mcn-releases/raw/refs/heads/main/Agartala/v0.2.0/CORE/release-images/iosmcn.agartala.v0.2.0.core.images.tar.gz
 tar -xvzf iosmcn.agartala.v0.2.0.core.images.tar.gz
-cd IOSMCN-CoreDpm
+cd iosmcn.agartala.v0.2.0.core.images/IOSMCN-CoreDpm
 ```
 
 This brings up a Kubernetes cluster, deploy a 5G version of IOSMCN-Core on that cluster, and then connect that IOSMCN-Core to either an emulated 5G RAN or physical RAN.

--- a/Agartala/v0.2.0/CORE/documentation/IOS-MCN CORE Installation Guide.md
+++ b/Agartala/v0.2.0/CORE/documentation/IOS-MCN CORE Installation Guide.md
@@ -138,7 +138,7 @@ sudo netplan apply
 Download file [iosmcn.agartala.v0.2.0.core.images.tar.gz](../release-images/iosmcn.agartala.v0.2.0.core.images.tar.gz) to the directory.
 
 ```
-wget https://github.com/ios-mcn/ios-mcn-releases/blob/main/Agartala/v0.2.0/CORE/release-images/iosmcn.agartala.v0.2.0.core.images.tar.gz
+wget https://github.com/ios-mcn/ios-mcn-releases/raw/refs/heads/main/Agartala/v0.2.0/CORE/release-images/iosmcn.agartala.v0.2.0.core.images.tar.gz
 tar -xvzf iosmcn.agartala.v0.2.0.core.images.tar.gz
 cd IOSMCN-CoreDpm
 ```


### PR DESCRIPTION
This PR fixes the incorrect GitHub web link that caused .tar.gz downloads to fail. This ensures users can directly download the release images using wget or curl.